### PR TITLE
model.py ppgen.py modifications

### DIFF
--- a/pseudo_dojo/ppcodes/ppgen.py
+++ b/pseudo_dojo/ppcodes/ppgen.py
@@ -452,15 +452,17 @@ class OncvMultiGenerator(object):
         #if icmod != 3:
         #    raise ValueError("Expecting icmod == 3 but got %s" % icmod)
 
-        name = os.path.basename(self.filepath).replace(".in", "")
+        base_name = os.path.basename(self.filepath).replace(".in", "")
         ppgens = []
         for fcfact, rcfact in product(fcfact_list, rcfact_list):
             new_input = self.template_lines[:]
             new_input[pos] = "%i %s %s" % (3, fcfact, rcfact)
             input_str = "\n".join(new_input)
-            print(input_str)
+            #print(input_str)
             ppgen = OncvGenerator(input_str, calc_type=self.calc_type)
-
+            
+            name = base_name + "_fcfact%3.2f_rcfact%3.2f" % (fcfact, rcfact)
+            ppgen.name = name
             ppgen.stdin_basename = name + ".in"
             ppgen.stdout_basename = name + ".out"
 
@@ -484,13 +486,15 @@ class OncvMultiGenerator(object):
         for ppgen in ok_ppgens:
             # Copy files to dest
             pseudo = ppgen.pseudo
-            dest = os.path.basename(self.filepath) + "_fcfact%3.2f_rcfact%3.2f" % (ppgen.fcfact, ppgen.rcfact)
-            shutil.copytree(ppgen.workdir, dest)
+            #dest = os.path.basename(self.filepath) + "_fcfact%3.2f_rcfact%3.2f" % (ppgen.fcfact, ppgen.rcfact)
+            dest = os.path.split(self.filepath)[0]
+            shutil.copy(os.path.join(ppgen.workdir,ppgen.stdin_basename), dest)
+            shutil.copy(os.path.join(ppgen.workdir,ppgen.stdout_basename), dest)
 
             # Reduce the number of ecuts in the DOJO_REPORT
             # Re-parse the output and use devel=True to overwrite initial psp8 file
-            psp8_path = os.path.join(dest, name + ".psp8")
-            out_path = os.path.join(dest, name + ".out")
+            psp8_path = os.path.join(dest, ppgen.name + ".psp8")
+            out_path = os.path.join(dest, ppgen.name + ".out")
 
             parser = OncvOutputParser(out_path)
             parser.scan()

--- a/pseudo_dojo/scripts/model.py
+++ b/pseudo_dojo/scripts/model.py
@@ -12,13 +12,16 @@ multi = OncvMultiGenerator(path)
 # Change the parameters of the model core charge, generate pseudos
 # and save results in new directories.
 # HEre we generate 2 pseudos, default args are: fcfact_list=(3, 4, 5), rcfact_list=(1.3, 1.35, 1.4, 1.45, 1.5, 1.55))
-pseudos = multi.change_icmod3(fcfact_list=(3,), rcfact_list=(1.3, 1.35))
-
+# pseudos = multi.change_icmod3(fcfact_list=(3,), rcfact_list=(1.3, 1.35))
+pseudos = multi.change_icmod3()
 commands = []
 for i, p in enumerate(pseudos):
     print("[%i] %s" % (i, p.filepath))
-    log = os.path.join(os.path.dirname(p.filepath), "log")
-    cmd = "nohup dojorun.py %s --trials=df --paral-kgb=0 > %s &" % (p.filepath, log)
+    dir = os.path.split(os.path.split(p.filepath)[0])[-1]
+    psp8 = os.path.split(p.filepath)[-1] 
+    log = 'log ' #os.path.join(dir, "log")
+    cmd = "nohup dojorun.py %s --trials=df --paral-kgb=0 > %s &" % (psp8, psp8 + '.log')
+#    cmd = "cd %s\ncp ../*.yml .\nnohup dojorun.py %s --trials=df --paral-kgb=0 > %s &\ncd .." % (dir, psp8, log)
     commands.append(cmd)
 
 for cmd in commands:


### PR DESCRIPTION
all generated pseudos get the specification in the filename. With this the dojos can be run from the base folder and the .yml files in the working folder are used and need not be copied. Moreover when all dojo's are done a table can be made from which we can read which pseudo gives which result.